### PR TITLE
Changed "parsley-debug-app" to "dill" internally

### DIFF
--- a/.github/workflows/dill-release.yml
+++ b/.github/workflows/dill-release.yml
@@ -106,7 +106,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dill-${{ matrix.platform }}.exe
-          path: ./src-tauri/target/release/parsley-debug-app.exe
+          path: ./src-tauri/target/release/dill.exe
           if-no-files-found: error
       
       - name: Upload app executable (Linux)
@@ -114,7 +114,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dill-${{ matrix.platform }}
-          path: ./src-tauri/target/release/parsley-debug-app
+          path: ./src-tauri/target/release/dill
           if-no-files-found: error
 
       - name: Upload app executable (MacOS)
@@ -122,7 +122,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dill-${{ matrix.platform }}
-          path: ./src-tauri/target/universal-apple-darwin/release/parsley-debug-app
+          path: ./src-tauri/target/universal-apple-darwin/release/dill
           if-no-files-found: error
 
       - name: Upload app bundles (Linux and Windows)

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -774,6 +774,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dill"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "mockall",
+ "rocket",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin-log",
+]
+
+[[package]]
 name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2677,20 +2691,6 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "parsley-debug-app"
-version = "0.1.0"
-dependencies = [
- "log",
- "mockall",
- "rocket",
- "serde",
- "serde_json",
- "tauri",
- "tauri-build",
- "tauri-plugin-log",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "parsley-debug-app"
+name = "dill"
 version = "0.1.0"
 description = "A cross-platform debugging UI for `parsley-debug`"
 authors = ["Jamie Willis (@j-mie6)", "Josh Walker (@josh-ja-walker)", "Aniket Gupta (@aniket1101)", "Priyansh Chugh (@PriyanshC)", "Alejandro Perez Fadon (@Aito0)", "Riley Horrix (@Riley-horrix)", "Adam Watson (@AdamW1087)"]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
     "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
-    "productName": "parsley-debug-app",
+    "productName": "dill",
     "version": "0.1.0",
     "identifier": "com.dill.dev",
     "build": {
@@ -12,7 +12,7 @@
     "app": {
         "windows": [
             {
-                "title": "Tree debugger",
+                "title": "Dill",
                 "width": 800,
                 "height": 600,
                 "resizable": true,


### PR DESCRIPTION
Note: for publicity purposes, all external references to the app (e.g. Github repo) will remain as "parsley-debug-app"