### PR TITLE
fix: Negative index of iterative children overflows to positive

### DIFF
--- a/frontend/src/main/scala/view/DebugTreeDisplay.scala
+++ b/frontend/src/main/scala/view/DebugTreeDisplay.scala
@@ -85,7 +85,10 @@ private object ReactiveNodeDisplay {
         /* Incrementing iterative node index */
         val moveIndex: Observer[Int] = iterativeNodeIndex.updater((currIndex, delta) => {
             /* Wrap indices of children around */
-            (currIndex + delta) % node.children.now().length
+            val childrenLen: Int = node.children.now().length
+            val indexSum: Int = (currIndex + delta) % childrenLen
+            
+            if (indexSum < 0) then indexSum + childrenLen else indexSum
         })
 
         /* Signal for when to show arrow buttons */


### PR DESCRIPTION
When scrolling through children of iterative nodes, we had a negative index overflow. That is now fixed.