### PR TITLE
fix: Add serde attribute for camelCase on PostTreeResponse

### DIFF
--- a/backend/src/server/request.rs
+++ b/backend/src/server/request.rs
@@ -14,6 +14,7 @@ pub fn routes() -> Vec<rocket::Route> {
 }
 
 #[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
 struct PostTreeResponse {
     message: String,
     #[serde(skip_serializing_if = "Option::is_none")] skip_breakpoint: Option<i32>,


### PR DESCRIPTION
This is BREAKING for breakpoints without a local snapshot, until the next PR into `parsley-debug-views`