### PR TITLE
feat: New field for nodes generated since the last breakpoint in backend trees

### DIFF
--- a/backend/src/trees/debug_tree.rs
+++ b/backend/src/trees/debug_tree.rs
@@ -45,7 +45,8 @@ impl From<SavedTree> for DebugTree {
                 node.child_id,
                 node.input,
                 children,
-                node.is_iterative
+                node.is_iterative,
+                node.newly_generated
             )
         }
 
@@ -68,12 +69,13 @@ pub struct DebugNode {
     #[serde(skip_serializing)] pub children: Vec<DebugNode>, /* The children of this node */
     pub is_leaf: bool,         /* Whether this node is a leaf node */
     pub is_iterative: bool,    /* Whether this node needs bubbling (iterative and transparent) */
+    pub newly_generated: bool, /* Whether this node was generated since the previous breakpoint */
 }
 
 impl DebugNode {
     pub fn new(node_id: u32, name: String, internal: String, success: bool, 
             child_id: Option<u32>, input: String, children: Vec<DebugNode>,
-            is_iterative: bool) -> Self {
+            is_iterative: bool, newly_generated: bool) -> Self {
 
         DebugNode {
             node_id,
@@ -84,7 +86,8 @@ impl DebugNode {
             input,
             is_leaf: children.is_empty(),
             children,
-            is_iterative
+            is_iterative,
+            newly_generated
         }
     }
 }
@@ -108,7 +111,8 @@ pub mod test {
                 "childId": 0,
                 "input": "Test",
                 "isLeaf": true,
-                "isIterative": false
+                "isIterative": false,
+                "newlyGenerated": false
             },
             "isDebuggable": false
         }"#
@@ -127,7 +131,8 @@ pub mod test {
                 "childId": 0,
                 "input": "0",
                 "isLeaf": false,
-                "isIterative": false
+                "isIterative": false,
+                "newlyGenerated": false
             },
             "isDebuggable": false
         }"#
@@ -146,6 +151,7 @@ pub mod test {
                 Some(0),
                 String::from("Test"),
                 Vec::new(),
+                false,
                 false
             ),
             false
@@ -179,9 +185,11 @@ pub mod test {
                                 Some(2),
                                 String::from("2"),
                                 vec![],
+                                false,
                                 false
                             )
                         ],
+                        false,
                         false
                     ),
                     DebugNode::new(
@@ -200,12 +208,15 @@ pub mod test {
                                 Some(4),
                                 String::from("4"),
                                 vec![],
+                                false,
                                 false
                             )
                         ],
+                        false,
                         false
                     )
                 ],
+                false,
                 false
             ),
             false

--- a/backend/src/trees/parsley_tree.rs
+++ b/backend/src/trees/parsley_tree.rs
@@ -14,6 +14,9 @@ pub struct ParsleyNode {
 
     /* Whether this node needs bubbling (iterative and transparent) */
     #[serde(default = "ParsleyTree::default_bool")] is_iterative: bool, 
+
+    /* Whether this node was generated since the previous breakpoint */
+    #[serde(default = "ParsleyTree::default_bool")] newly_generated: bool, 
 }
 
 #[derive(Debug, PartialEq, serde::Deserialize)]
@@ -68,7 +71,8 @@ impl From<ParsleyTree> for DebugTree {
                 child_id,
                 input_slice,
                 children,
-                node.is_iterative
+                node.is_iterative,
+                node.newly_generated,
             )
         }
 
@@ -182,7 +186,8 @@ pub mod test {
                 from_offset: 0,
                 to_offset: 4,
                 children: vec![],
-                is_iterative: false
+                is_iterative: false,
+                newly_generated: false,
             },
             is_debuggable: false,
         }
@@ -215,10 +220,12 @@ pub mod test {
                                 from_offset: 2,
                                 to_offset: 3,
                                 children: vec![],
-                                is_iterative: false
+                                is_iterative: false,
+                                newly_generated: false,
                             }
                         ],
-                        is_iterative: false
+                        is_iterative: false,
+                        newly_generated: false,
                     },
                     ParsleyNode {
                         name: String::from("3"),
@@ -236,13 +243,16 @@ pub mod test {
                                 from_offset: 4,
                                 to_offset: 5,
                                 children: vec![],
-                                is_iterative: false
+                                is_iterative: false,
+                                newly_generated: false,
                             }
                         ],
-                        is_iterative: false
+                        is_iterative: false,
+                        newly_generated: false,
                     }
                 ],
                 is_iterative: false,
+                newly_generated: false,
             },
             is_debuggable: false,
         }

--- a/backend/src/trees/saved_tree.rs
+++ b/backend/src/trees/saved_tree.rs
@@ -18,6 +18,7 @@ pub struct SavedNode {
     pub input: String,              /* Offset into the input in which this node's parse attempt finished */
     pub children: Vec<SavedNode>,   /* The children of this node */
     pub is_iterative: bool,         /* Whether this node needs bubbling (iterative and transparent) */
+    pub newly_generated: bool,      /* Whether this node was generated since the previous breakpoint */
 } 
 
 impl From<DebugTree> for SavedTree {
@@ -39,7 +40,8 @@ impl From<DebugTree> for SavedTree {
                 node.child_id,
                 node.input,
                 children,
-                node.is_iterative
+                node.is_iterative,
+                node.newly_generated,
             )
         }
 
@@ -74,7 +76,7 @@ impl SavedTree {
 impl SavedNode {
     pub fn new(node_id: u32, name: String, internal: String, success: bool, 
             child_id: Option<u32>, input: String, children: Vec<SavedNode>,
-            is_iterative: bool) -> Self {
+            is_iterative: bool, newly_generated: bool) -> Self {
 
         SavedNode {
             node_id,
@@ -84,7 +86,8 @@ impl SavedNode {
             child_id,
             input,
             children,
-            is_iterative
+            is_iterative,
+            newly_generated,
         }
     }
 }
@@ -115,7 +118,8 @@ pub mod test {
                 "child_id": 0,
                 "input": "Test",
                 "children": [],
-                "is_iterative": false
+                "is_iterative": false,
+                "newly_generated": false
             },
             "is_debuggable": false
         }"#
@@ -150,10 +154,12 @@ pub mod test {
                                 "child_id": 2,
                                 "input": "2",
                                 "children": [],
-                                "is_iterative": false
+                                "is_iterative": false,
+                                "newly_generated": false
                             }
                         ],
-                        "is_iterative": false
+                        "is_iterative": false,
+                        "newly_generated": false
                     },
                     {
                         "node_id": 3,
@@ -171,13 +177,16 @@ pub mod test {
                                 "child_id": 4,
                                 "input": "4",
                                 "children": [],
-                                "is_iterative": false
+                                "is_iterative": false,
+                                "newly_generated": false
                             }
                         ],
-                        "is_iterative": false
+                        "is_iterative": false,
+                        "newly_generated": false
                     }
                 ],
-                "is_iterative": false
+                "is_iterative": false,
+                "newly_generated": false
             },
             "is_debuggable": false
         }"#
@@ -196,6 +205,7 @@ pub mod test {
                 Some(0),
                 String::from("Test"),
                 Vec::new(),
+                false,
                 false
             ),
             false
@@ -229,9 +239,11 @@ pub mod test {
                                 Some(2),
                                 String::from("2"),
                                 vec![],
+                                false,
                                 false
                             )
                         ],
+                        false,
                         false
                     ),
                     SavedNode::new(
@@ -250,12 +262,15 @@ pub mod test {
                                 Some(4),
                                 String::from("4"),
                                 vec![],
+                                false,
                                 false
                             )
                         ],
+                        false,
                         false
                     )
                 ],
+                false,
                 false
             ),
             false


### PR DESCRIPTION
The usual case, new field in all three backend trees and update tests to use them 😵‍💫
This field will be `true` when the node has been generated since the last breakpoint - which lets us do extra CSS on them specifically like hightlighting