### PR TITLE
`flatMapMerge` -> `flatMapSwitch`

### DIFF
--- a/frontend/src/main/scala/controller/viewControllers/TreeViewController.scala
+++ b/frontend/src/main/scala/controller/viewControllers/TreeViewController.scala
@@ -74,7 +74,7 @@ object TreeViewController {
         sessionId
             .withCurrentValueOf(SettingsViewController.getNumSkipBreakpoints.signal)
             .map((sessionId, skips) => (sessionId, skips - 1))
-            .flatMapMerge(Tauri.invoke(Command.SkipBreakpoints, _)) // FIXME: I think this can be a flatMapSwitch?
+            .flatMapSwitch(Tauri.invoke(Command.SkipBreakpoints, _))
     }
 
     val isDebuggingSession: Signal[Boolean] = tree.signal.map(_.exists(_.isDebuggable))

--- a/frontend/src/main/scala/view/DebugTreeDisplay.scala
+++ b/frontend/src/main/scala/view/DebugTreeDisplay.scala
@@ -308,18 +308,17 @@ private object ReactiveNodeDisplay {
                     onClick(_
                         .filter(_ => !node.debugNode.isLeaf)
                         .sample(expansionState)
-                        .flatMapMerge { // FIXME: I think this can be a flatMapSwitch?
-                            _ match
-                                case ExpansionState.AllChildren =>
-                                    EventStream.fromValue(Nil)
-                                case ExpansionState.OneIterativeChild =>
-                                    expandAllChildren.set(true)
-                                    Tauri.invoke(Command.FetchNodeChildren, node.debugNode.nodeId).collectRight
-                                case ExpansionState.NoChildren =>
-                                    if (node.debugNode.isIterative) {
-                                        expandAllChildren.set(false)
-                                    }
-                                    Tauri.invoke(Command.FetchNodeChildren, node.debugNode.nodeId).collectRight
+                        .flatMapSwitch {
+                            case ExpansionState.AllChildren =>
+                                EventStream.fromValue(Nil)
+                            case ExpansionState.OneIterativeChild =>
+                                expandAllChildren.set(true)
+                                Tauri.invoke(Command.FetchNodeChildren, node.debugNode.nodeId).collectRight
+                            case ExpansionState.NoChildren =>
+                                if (node.debugNode.isIterative) {
+                                    expandAllChildren.set(false)
+                                }
+                                Tauri.invoke(Command.FetchNodeChildren, node.debugNode.nodeId).collectRight
                         }
                     ) --> node.children.writer
                 ),

--- a/frontend/src/main/scala/view/DebugViewPage.scala
+++ b/frontend/src/main/scala/view/DebugViewPage.scala
@@ -64,8 +64,8 @@ abstract class DebugViewPage extends Page {
         /* Exports current tree */
         onClick(_
             .sample(TabViewController.getSelectedTab)
-            .flatMapMerge(TreeViewController.downloadTree) // FIXME: I think this can be a flatMapSwitch?
-        .map {
+            .flatMapSwitch(TreeViewController.downloadTree)
+            .map {
                 case Left(_) => TreeDownloadFailed
                 case Right(_) =>  TreeDownloaded
             }

--- a/frontend/src/main/scala/view/MainView.scala
+++ b/frontend/src/main/scala/view/MainView.scala
@@ -70,7 +70,7 @@ object MainView extends DebugViewPage {
                 newTreeStream
                     .collectRight
                     .sample(TreeViewController.getSessionName.map(FileCounter.freshName))
-                    .flatMapMerge(TabViewController.saveTree) --> tabBus.writer, // FIXME: I think this can be a flatMapSwitch?
+                    .flatMapSwitch(TabViewController.saveTree) --> tabBus.writer,
 
                 /* Update file names */
                 tabBus.stream.collectRight --> TabViewController.setFileNames,

--- a/frontend/src/main/scala/view/TabView.scala
+++ b/frontend/src/main/scala/view/TabView.scala
@@ -76,7 +76,7 @@ object TabView {
 
             /* Update tree on new tab selected */
             TabViewController.getSelectedTab.changes
-                .flatMapMerge(TabViewController.loadSavedTree) // FIXME: I think this can be a flatMapSwitch?
+                .flatMapSwitch(TabViewController.loadSavedTree)
                 .collectLeft --> controller.errors.ErrorController.setError,
 
             TabViewController.getSelectedTab.changes

--- a/frontend/src/main/scala/view/TreeView.scala
+++ b/frontend/src/main/scala/view/TreeView.scala
@@ -31,8 +31,7 @@ object TreeView {
             .mapToUnit
             --> StateManagementViewController.clearRefs,
 
-        TreeViewController.getSessionId.changes
-            .flatMapMerge(TreeViewController.getRefs) --> returnBus.writer, // FIXME: I think this can be a flatMapSwitch?
+        TreeViewController.getSessionId.changes.flatMapSwitch(TreeViewController.getRefs) --> returnBus.writer,
 
         returnBus.stream.collectRight --> seqBus.writer,
         returnBus.stream.collectLeft --> ErrorController.setError,


### PR DESCRIPTION
Did some reading, we definitely wanted the `Switch` variant: it will stop listening to the old stream when the next one is due to start. The way we had it before was that it would keep listening to all the last streams ever created from that signal. Obviously, as our commands are one-shot, this doesn't make any operational difference, but it will be much less efficient.