### PR TITLE
Fix node line colouring to defer to parent

### DIFF
--- a/frontend/styles/displays/debug-tree.css
+++ b/frontend/styles/displays/debug-tree.css
@@ -136,6 +136,18 @@
     background-color: var(--node-font-color);
 }
 
+.debug-node-container.fail > .debug-node-children-container > .debug-node-container > .debug-node-line {
+    background-color: var(--node-font-color-fail) !important;
+}
+
+.debug-node-container.iterative > .debug-node-children-container > .debug-node-container > .debug-node-line {
+    background-color: var(--node-font-color-iterative);
+}
+
+.debug-node-container.debug > .debug-node-children-container > .debug-node-container > .debug-node-line {
+    background-color: var(--node-font-color-debug);
+}
+
 /* No node-line displayed on the first node */
 .debug-tree-container:first-child > .debug-node-container > .debug-node-line {
     display: none !important;


### PR DESCRIPTION
## New Version
<img width="2216" height="1115" alt="image" src="https://github.com/user-attachments/assets/3cc9f073-b098-4c1c-bbf4-1bf8cc1dfd37" />


## Old Version
<img width="1355" height="787" alt="image" src="https://github.com/user-attachments/assets/c7bb7b82-4e10-498d-8441-037a9e22b212" />

